### PR TITLE
Add Strict FilterStrategy

### DIFF
--- a/src/Attribute/MultiTenancy/FilterStrategy.php
+++ b/src/Attribute/MultiTenancy/FilterStrategy.php
@@ -14,4 +14,5 @@ enum FilterStrategy
 
     case FirstMatch;
     case AnyMatch;
+    case Strict;
 }

--- a/src/ConditionResolver.php
+++ b/src/ConditionResolver.php
@@ -196,6 +196,36 @@ class ConditionResolver
             }
         }
 
+        if ($multiTenancy->getFilterStrategy() === FilterStrategy::Strict
+            && $this->hasUncoveredContexts($filters)
+        ) {
+            $whereClauses[] = '1 = 0';
+        }
+
         return implode(' AND ', $whereClauses);
+    }
+
+
+    /**
+     * Checks whether any active context is not covered by a filter's context array
+     *
+     * @param FilterAttribute[] $filters
+     */
+    private function hasUncoveredContexts(array $filters): bool
+    {
+        $coveredContexts = [];
+        foreach ($filters as $filter) {
+            foreach ($filter->getContext() as $context) {
+                $coveredContexts[$context] = true;
+            }
+        }
+
+        foreach ($this->listener->getContextProviders() as $contextProvider) {
+            if ($contextProvider->isContextual() && !isset($coveredContexts[$contextProvider->getIdentifier()])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Fixture/Entity/StrictEntity.php
+++ b/tests/Fixture/Entity/StrictEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity;
+
+use Rentpost\Doctrine\MultiTenancy\Attribute\MultiTenancy;
+
+#[MultiTenancy(
+    strategy: MultiTenancy\FilterStrategy::Strict,
+    filters: [
+        new MultiTenancy\Filter(where: '$this.store_id = {storeId}'),
+        new MultiTenancy\Filter(
+            context: ['staff'],
+            ignore: true,
+        ),
+        new MultiTenancy\Filter(
+            context: ['customer'],
+            where: '$this.id IN(SELECT book_id FROM customer_purchase WHERE customer_id = {customerId})',
+        ),
+        new MultiTenancy\Filter(
+            context: ['publisher'],
+            where: '$this.publisher_id = {publisherId}',
+        ),
+    ],
+)]
+class StrictEntity
+{
+}

--- a/tests/Fixture/Entity/StrictNoContextFreeEntity.php
+++ b/tests/Fixture/Entity/StrictNoContextFreeEntity.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity;
+
+use Rentpost\Doctrine\MultiTenancy\Attribute\MultiTenancy;
+
+#[MultiTenancy(
+    strategy: MultiTenancy\FilterStrategy::Strict,
+    filters: [
+        new MultiTenancy\Filter(
+            context: ['customer'],
+            where: '$this.id IN(SELECT book_id FROM customer_purchase WHERE customer_id = {customerId})',
+        ),
+        new MultiTenancy\Filter(
+            context: ['publisher'],
+            where: '$this.publisher_id = {publisherId}',
+        ),
+    ],
+)]
+class StrictNoContextFreeEntity
+{
+}

--- a/tests/Unit/Attribute/MultiTenancy/FilterStrategyTest.php
+++ b/tests/Unit/Attribute/MultiTenancy/FilterStrategyTest.php
@@ -22,8 +22,14 @@ class FilterStrategyTest extends TestCase
     }
 
 
+    public function testStrictCaseExists(): void
+    {
+        $this->assertSame('Strict', FilterStrategy::Strict->name);
+    }
+
+
     public function testCaseCount(): void
     {
-        $this->assertCount(2, FilterStrategy::cases());
+        $this->assertCount(3, FilterStrategy::cases());
     }
 }

--- a/tests/Unit/ConditionResolverTest.php
+++ b/tests/Unit/ConditionResolverTest.php
@@ -17,6 +17,8 @@ use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\Order;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\Product;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\Review;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\UnmappedEntity;
+use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\StrictEntity;
+use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\StrictNoContextFreeEntity;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\Wishlist;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\StubContextProvider;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\StubValueHolder;
@@ -322,5 +324,113 @@ class ConditionResolverTest extends TestCase
         $result = $resolver->resolve(Review::class, 't0');
 
         $this->assertSame('', $result);
+    }
+
+
+    public function testStrictCoveredContextAppliesNormally(): void
+    {
+        $listener = $this->createListener(
+            [
+                new StubValueHolder('storeId', '42'),
+                new StubValueHolder('customerId', '7'),
+            ],
+            [
+                new StubContextProvider('staff', false),
+                new StubContextProvider('customer', true),
+                new StubContextProvider('publisher', false),
+            ],
+        );
+        $resolver = new ConditionResolver($listener);
+
+        // StrictEntity: customer is covered and active → normal filters, no denial
+        $result = $resolver->resolve(StrictEntity::class, 't0');
+
+        $this->assertSame(
+            't0.store_id = 42 AND t0.id IN(SELECT book_id FROM customer_purchase WHERE customer_id = 7)',
+            $result,
+        );
+    }
+
+
+    public function testStrictIgnoredContextIsCovered(): void
+    {
+        $listener = $this->createListener(
+            [new StubValueHolder('storeId', '42')],
+            [
+                new StubContextProvider('staff', true),
+                new StubContextProvider('customer', false),
+                new StubContextProvider('publisher', false),
+            ],
+        );
+        $resolver = new ConditionResolver($listener);
+
+        // StrictEntity: staff is covered (ignore: true) → only context-free filter, no denial
+        $result = $resolver->resolve(StrictEntity::class, 't0');
+
+        $this->assertSame('t0.store_id = 42', $result);
+    }
+
+
+    public function testStrictUncoveredContextDenied(): void
+    {
+        $listener = $this->createListener(
+            [new StubValueHolder('storeId', '42')],
+            [
+                new StubContextProvider('staff', false),
+                new StubContextProvider('customer', false),
+                new StubContextProvider('publisher', false),
+                new StubContextProvider('vendor', true),
+            ],
+        );
+        $resolver = new ConditionResolver($listener);
+
+        // StrictEntity: vendor is active but not in any filter's context → denied
+        $result = $resolver->resolve(StrictEntity::class, 't0');
+
+        $this->assertSame('t0.store_id = 42 AND 1 = 0', $result);
+    }
+
+
+    public function testStrictNoActiveContextUsesContextFreeFilters(): void
+    {
+        $listener = $this->createListener(
+            [new StubValueHolder('storeId', '42')],
+            [
+                new StubContextProvider('staff', false),
+                new StubContextProvider('customer', false),
+                new StubContextProvider('publisher', false),
+            ],
+        );
+        $resolver = new ConditionResolver($listener);
+
+        // StrictEntity: no context active → only context-free filters, no denial
+        $result = $resolver->resolve(StrictEntity::class, 't0');
+
+        $this->assertSame('t0.store_id = 42', $result);
+    }
+
+
+    public function testStrictMultipleActiveContextsOneCovered(): void
+    {
+        $listener = $this->createListener(
+            [
+                new StubValueHolder('storeId', '42'),
+                new StubValueHolder('customerId', '7'),
+            ],
+            [
+                new StubContextProvider('customer', true),
+                new StubContextProvider('publisher', false),
+                new StubContextProvider('vendor', true),
+            ],
+        );
+        $resolver = new ConditionResolver($listener);
+
+        // StrictNoContextFreeEntity: customer covered, vendor NOT → denied
+        $result = $resolver->resolve(StrictNoContextFreeEntity::class, 't0');
+
+        $this->assertSame(
+            't0.id IN(SELECT book_id FROM customer_purchase WHERE customer_id = 7) AND 1 = 0',
+            $result,
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Adds `Strict` case to the `FilterStrategy` enum — a deny-by-default strategy
- Processes filters like `AnyMatch`, but after the filter loop, if any active `ContextProvider` is not covered by any filter's `context:` array, appends `1 = 0` (denying all results)
- `ignore: true` counts as "covered" — the context is acknowledged, just without extra conditions

## Key behaviors
- Context-free filters (empty `context: []`) still apply to all contexts
- Only one `1 = 0` is ever appended (early return on first uncovered context)
- If no `ContextProvider` is active at all, no denial occurs

## Test plan
- [x] 5 new test cases in `ConditionResolverTest`: covered context, ignored-as-covered, uncovered denial, no-active-context, multiple-active-one-uncovered
- [x] Updated `FilterStrategyTest` for 3 enum cases
- [x] All 46 tests pass