### PR TITLE
Add AmbientContextProviderInterface for Strict strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,21 @@ Using the `Admin` example above, we might return `admin` as an "identifier". The
 
 As with the `ValueHolder`, this will all be more clear when viewing the example attributes below.
 
+#### Ambient Context Providers
+
+Some context providers represent ambient environmental state rather than primary access contexts — for example, "is any role active?" or "is a user logged in?". These are always active and don't represent discrete access levels.
+
+When using `FilterStrategy::Strict`, ambient contexts could cause universal denial, if they're not defined in a filter's `context:` array. To prevent this, implement `AmbientContextProviderInterface` (a marker interface extending `ContextProviderInterface`) on those providers. Strict will skip them during its coverage check.
+
+```php
+use Rentpost\Doctrine\MultiTenancy\AmbientContextProviderInterface;
+
+class UserContextProvider implements AmbientContextProviderInterface
+{
+    // ...
+}
+```
+
 ## Usage
 
 After you've gotten everything setup, the hard part is out of the way. Taking the time to properly evaludate how you'll setup your `ValueHolder` and `ContextProvider` classes will go a long way in making the usage clean and simple.

--- a/src/AmbientContextProviderInterface.php
+++ b/src/AmbientContextProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rentpost\Doctrine\MultiTenancy;
+
+/**
+ * Marker interface for context providers that represent ambient environmental
+ * state rather than primary access contexts.
+ *
+ * Context providers implementing this interface are excluded from the Strict
+ * strategy's coverage enforcement. Use this for "always on" contexts
+ * (e.g., "any role active", "user logged in") that don't represent discrete
+ * access levels.
+ *
+ * @author Jacob Thomason <jacob@rentpost.com>
+ */
+interface AmbientContextProviderInterface extends ContextProviderInterface {}

--- a/src/ConditionResolver.php
+++ b/src/ConditionResolver.php
@@ -221,6 +221,10 @@ class ConditionResolver
         }
 
         foreach ($this->listener->getContextProviders() as $contextProvider) {
+            if ($contextProvider instanceof AmbientContextProviderInterface) {
+                continue;
+            }
+
             if ($contextProvider->isContextual() && !isset($coveredContexts[$contextProvider->getIdentifier()])) {
                 return true;
             }

--- a/tests/Fixture/StubAmbientContextProvider.php
+++ b/tests/Fixture/StubAmbientContextProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rentpost\Doctrine\MultiTenancy\Tests\Fixture;
+
+use Rentpost\Doctrine\MultiTenancy\AmbientContextProviderInterface;
+
+class StubAmbientContextProvider implements AmbientContextProviderInterface
+{
+
+    public function __construct(
+        private readonly string $identifier,
+        private readonly bool $contextual,
+    ) {}
+
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+
+    public function isContextual(): bool
+    {
+        return $this->contextual;
+    }
+}

--- a/tests/Unit/ConditionResolverTest.php
+++ b/tests/Unit/ConditionResolverTest.php
@@ -16,10 +16,11 @@ use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\MisconfiguredEntity;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\Order;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\Product;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\Review;
-use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\UnmappedEntity;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\StrictEntity;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\StrictNoContextFreeEntity;
+use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\UnmappedEntity;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\Wishlist;
+use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\StubAmbientContextProvider;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\StubContextProvider;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\StubValueHolder;
 
@@ -432,5 +433,47 @@ class ConditionResolverTest extends TestCase
             't0.id IN(SELECT book_id FROM customer_purchase WHERE customer_id = 7) AND 1 = 0',
             $result,
         );
+    }
+
+
+    public function testStrictAmbientContextIsSkipped(): void
+    {
+        $listener = $this->createListener(
+            [new StubValueHolder('storeId', '42')],
+            [
+                new StubContextProvider('staff', false),
+                new StubContextProvider('customer', false),
+                new StubContextProvider('publisher', false),
+                new StubAmbientContextProvider('role', true),
+                new StubAmbientContextProvider('user', true),
+            ],
+        );
+        $resolver = new ConditionResolver($listener);
+
+        // StrictEntity: role and user are active but ambient → skipped, no denial
+        $result = $resolver->resolve(StrictEntity::class, 't0');
+
+        $this->assertSame('t0.store_id = 42', $result);
+    }
+
+
+    public function testStrictAmbientContextDoesNotMaskUncovered(): void
+    {
+        $listener = $this->createListener(
+            [new StubValueHolder('storeId', '42')],
+            [
+                new StubContextProvider('staff', false),
+                new StubContextProvider('customer', false),
+                new StubContextProvider('publisher', false),
+                new StubContextProvider('vendor', true),
+                new StubAmbientContextProvider('role', true),
+            ],
+        );
+        $resolver = new ConditionResolver($listener);
+
+        // StrictEntity: role is ambient (skipped), but vendor is active and uncovered → denied
+        $result = $resolver->resolve(StrictEntity::class, 't0');
+
+        $this->assertSame('t0.store_id = 42 AND 1 = 0', $result);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `AmbientContextProviderInterface` — a marker interface for context providers that represent always-on environmental state (e.g., "any role active", "user logged in")
- Strict strategy now skips ambient providers during coverage checks, preventing universal denial from meta-contexts
- Fully backward-compatible — existing providers default to being checked

## Context
`FilterStrategy::Strict` denies access when an active context isn't covered by any filter. But meta-contexts like `role` (always true when authenticated) and `user` (always true when a user is on the stack) are never listed in filter `context:` arrays — they'd cause every query to be denied, including managers.

## Test plan
- [x] `testStrictAmbientContextIsSkipped` — ambient providers active but skipped, no denial
- [x] `testStrictAmbientContextDoesNotMaskUncovered` — ambient skipped but non-ambient uncovered context still triggers denial
- [x] All 48 tests pass