### PR TITLE
Fix: context-free filters cover all contexts under strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ This eliminates the need to explicitly deny every uncovered context. Only contex
 
 Note: `strict` is orthogonal to `FilterStrategy` — it works with either `AnyMatch` or `FirstMatch`.
 
+#### Context-free filters
+
+A filter with no `context:` array applies to all contexts (as documented earlier), and consistent with that semantic, it also **covers** all contexts for the strict check. So mixing a context-free filter with `strict: true` effectively disables the coverage enforcement — every active context is implicitly covered.
+
+For strict mode to be meaningful, declare a `context:` array on every filter so coverage is explicit. The following example scopes access contextually: managers get company-wide access, admins are permitted without extra conditions (`ignore: true`), and anyone else is denied.
+
 ```php
 use Doctrine\ORM\Mapping as ORM;
 use Rentpost\Doctrine\MultiTenancy\Attribute\MultiTenancy;
@@ -229,18 +235,13 @@ use Rentpost\Doctrine\MultiTenancy\Attribute\MultiTenancy;
 #[MultiTenancy(
     strict: true,
     filters: [
-        new MultiTenancy\Filter(where: '$this.company_id = {companyId}'),
+        new MultiTenancy\Filter(
+            context: ['manager'],
+            where: '$this.company_id = {companyId}',
+        ),
         new MultiTenancy\Filter(
             context: ['admin'],
             ignore: true,
-        ),
-        new MultiTenancy\Filter(
-            context: ['manager'],
-            where: '$this.id IN(
-                SELECT product_id
-                FROM manager_product
-                WHERE manager_id = {managerId}
-            )',
         ),
     ],
 )]
@@ -251,9 +252,8 @@ class Product
 ```
 
 In this example:
-- The `company_id` filter (no context) always applies
-- An `admin` sees company-wide data (ignored filter, but the context is acknowledged as covered)
-- A `manager` gets the additional scoping filter
+- A `manager` sees products scoped to their company
+- An `admin` sees everything (ignored filter, but the context is acknowledged as covered)
 - Any other active context (e.g. `guest`) is automatically denied — no need to add explicit deny filters
 
 #### Ambient Context Providers

--- a/src/ConditionResolver.php
+++ b/src/ConditionResolver.php
@@ -205,7 +205,11 @@ class ConditionResolver
 
 
     /**
-     * Checks whether any active context is not covered by a filter's context array
+     * Checks whether any active context is not covered by a filter's context array.
+     *
+     * A filter with no context array (context-free) is considered to apply to all
+     * contexts — consistent with query-application semantics — so it covers every
+     * active context for the purpose of the strict coverage check.
      *
      * @param FilterAttribute[] $filters
      */
@@ -213,6 +217,10 @@ class ConditionResolver
     {
         $coveredContexts = [];
         foreach ($filters as $filter) {
+            if (!count($filter->getContext())) {
+                return false;
+            }
+
             foreach ($filter->getContext() as $context) {
                 $coveredContexts[$context] = true;
             }

--- a/tests/Fixture/Entity/FirstMatchWithContextFreeEntity.php
+++ b/tests/Fixture/Entity/FirstMatchWithContextFreeEntity.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity;
+
+use Rentpost\Doctrine\MultiTenancy\Attribute\MultiTenancy;
+use Rentpost\Doctrine\MultiTenancy\Attribute\MultiTenancy\FilterStrategy;
+
+#[MultiTenancy(strategy: FilterStrategy::FirstMatch, filters: [
+    new MultiTenancy\Filter(where: '$this.store_id = {storeId}'),
+    new MultiTenancy\Filter(
+        context: ['customer'],
+        where: '$this.id IN(SELECT book_id FROM customer_purchase WHERE customer_id = {customerId})',
+    ),
+])]
+class FirstMatchWithContextFreeEntity
+{
+}

--- a/tests/Unit/ConditionResolverTest.php
+++ b/tests/Unit/ConditionResolverTest.php
@@ -11,6 +11,7 @@ use Rentpost\Doctrine\MultiTenancy\KeyValueException;
 use Rentpost\Doctrine\MultiTenancy\Listener;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\Book;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\ExternalCatalog;
+use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\FirstMatchWithContextFreeEntity;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\Invoice;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\MisconfiguredEntity;
 use Rentpost\Doctrine\MultiTenancy\Tests\Fixture\Entity\Order;
@@ -146,6 +147,26 @@ class ConditionResolverTest extends TestCase
         // Review: staff filter first, customer filter second, both contextual
         // FirstMatch should only use the staff filter
         $result = $resolver->resolve(Review::class, 't0');
+
+        $this->assertSame('t0.store_id = 42', $result);
+    }
+
+
+    public function testFirstMatchContextFreeFilterShortCircuitsSubsequent(): void
+    {
+        $listener = $this->createListener(
+            [
+                new StubValueHolder('storeId', '42'),
+                new StubValueHolder('customerId', '7'),
+            ],
+            [new StubContextProvider('customer', true)],
+        );
+        $resolver = new ConditionResolver($listener);
+
+        // FirstMatchWithContextFreeEntity: context-free filter first, customer filter second.
+        // Context-free is always contextual → always matches first → subsequent filters
+        // never evaluated, even when their contexts are active.
+        $result = $resolver->resolve(FirstMatchWithContextFreeEntity::class, 't0');
 
         $this->assertSame('t0.store_id = 42', $result);
     }

--- a/tests/Unit/ConditionResolverTest.php
+++ b/tests/Unit/ConditionResolverTest.php
@@ -365,14 +365,14 @@ class ConditionResolverTest extends TestCase
         );
         $resolver = new ConditionResolver($listener);
 
-        // StrictEntity: staff is covered (ignore: true) → only context-free filter, no denial
+        // StrictEntity: staff is active and covered (listed via ignore: true filter, also via context-free) → no denial
         $result = $resolver->resolve(StrictEntity::class, 't0');
 
         $this->assertSame('t0.store_id = 42', $result);
     }
 
 
-    public function testStrictUncoveredContextDenied(): void
+    public function testStrictContextFreeFilterCoversAllContexts(): void
     {
         $listener = $this->createListener(
             [new StubValueHolder('storeId', '42')],
@@ -385,10 +385,32 @@ class ConditionResolverTest extends TestCase
         );
         $resolver = new ConditionResolver($listener);
 
-        // StrictEntity: vendor is active but not in any filter's context → denied
+        // StrictEntity has a context-free filter which, consistent with "applies to all",
+        // also covers all contexts. Vendor is active and not explicitly listed, but the
+        // context-free filter means strict has nothing to enforce.
         $result = $resolver->resolve(StrictEntity::class, 't0');
 
-        $this->assertSame('t0.store_id = 42 AND 1 = 0', $result);
+        $this->assertSame('t0.store_id = 42', $result);
+    }
+
+
+    public function testStrictUncoveredContextDenied(): void
+    {
+        $listener = $this->createListener(
+            [],
+            [
+                new StubContextProvider('customer', false),
+                new StubContextProvider('publisher', false),
+                new StubContextProvider('vendor', true),
+            ],
+        );
+        $resolver = new ConditionResolver($listener);
+
+        // StrictNoContextFreeEntity has only contextual filters. Vendor is active but
+        // not in any filter's context → denied.
+        $result = $resolver->resolve(StrictNoContextFreeEntity::class, 't0');
+
+        $this->assertSame('1 = 0', $result);
     }
 
 
@@ -439,10 +461,9 @@ class ConditionResolverTest extends TestCase
     public function testStrictAmbientContextIsSkipped(): void
     {
         $listener = $this->createListener(
-            [new StubValueHolder('storeId', '42')],
+            [new StubValueHolder('customerId', '7')],
             [
-                new StubContextProvider('staff', false),
-                new StubContextProvider('customer', false),
+                new StubContextProvider('customer', true),
                 new StubContextProvider('publisher', false),
                 new StubAmbientContextProvider('role', true),
                 new StubAmbientContextProvider('user', true),
@@ -450,20 +471,23 @@ class ConditionResolverTest extends TestCase
         );
         $resolver = new ConditionResolver($listener);
 
-        // StrictEntity: role and user are active but ambient → skipped, no denial
-        $result = $resolver->resolve(StrictEntity::class, 't0');
+        // StrictNoContextFreeEntity: customer covered and active. Ambients (role, user)
+        // active but skipped during coverage check. No denial.
+        $result = $resolver->resolve(StrictNoContextFreeEntity::class, 't0');
 
-        $this->assertSame('t0.store_id = 42', $result);
+        $this->assertSame(
+            't0.id IN(SELECT book_id FROM customer_purchase WHERE customer_id = 7)',
+            $result,
+        );
     }
 
 
     public function testStrictAmbientContextDoesNotMaskUncovered(): void
     {
         $listener = $this->createListener(
-            [new StubValueHolder('storeId', '42')],
+            [new StubValueHolder('customerId', '7')],
             [
-                new StubContextProvider('staff', false),
-                new StubContextProvider('customer', false),
+                new StubContextProvider('customer', true),
                 new StubContextProvider('publisher', false),
                 new StubContextProvider('vendor', true),
                 new StubAmbientContextProvider('role', true),
@@ -471,9 +495,13 @@ class ConditionResolverTest extends TestCase
         );
         $resolver = new ConditionResolver($listener);
 
-        // StrictEntity: role is ambient (skipped), but vendor is active and uncovered → denied
-        $result = $resolver->resolve(StrictEntity::class, 't0');
+        // StrictNoContextFreeEntity: role is ambient (skipped), customer covered,
+        // but vendor is active and uncovered → denied
+        $result = $resolver->resolve(StrictNoContextFreeEntity::class, 't0');
 
-        $this->assertSame('t0.store_id = 42 AND 1 = 0', $result);
+        $this->assertSame(
+            't0.id IN(SELECT book_id FROM customer_purchase WHERE customer_id = 7) AND 1 = 0',
+            $result,
+        );
     }
 }


### PR DESCRIPTION
## Summary
Fixes an inconsistency between how context-free filters are handled during query composition vs the strict coverage check.

A filter with no \`context:\` array is documented as "applies to all contexts" — and that's exactly how matching strategies treat it. But the strict coverage check was treating context-free filters as contributing *no* coverage. That meant adding a base \`company_id = X\` filter (a very common pattern) silently made strict mode deny all real contexts.

Now context-free filters cover all contexts for the strict check too. "Applies to all" and "covers all" align.

## Behavior changes
- \`strict: true\` + any context-free filter = no denial ever (context-free covers everything)
- \`strict: true\` + only contextual filters = denies active contexts not listed (strict works as designed)
- To use strict meaningfully, declare \`context:\` on every filter

## Tests
- [x] New: \`testStrictContextFreeFilterCoversAllContexts\` — proves the new semantic
- [x] Updated: \`testStrictUncoveredContextDenied\` — uses \`StrictNoContextFreeEntity\` (contextual-only) to actually test denial
- [x] Updated: \`testStrictAmbientContext*\` — switched to \`StrictNoContextFreeEntity\` so ambient-skip logic is actually exercised
- [x] README updated with a "Context-free filters" note explaining the interaction

All 49 tests pass.